### PR TITLE
Use aspect-square class for gallery thumbnails

### DIFF
--- a/src/components/GalleryItem.tsx
+++ b/src/components/GalleryItem.tsx
@@ -11,12 +11,11 @@ interface GalleryItemProps {
 
 const GalleryItem: React.FC<GalleryItemProps> = ({ src, alt, onClick }) => {
   return (
-    <div 
+    <div
       // className="relative aspect-w-1 aspect-h-1 rounded-lg overflow-hidden cursor-pointer group transform hover:scale-105 transition-transform duration-300 shadow-lg hover:shadow-xl"
       // className="relative w-60 h-60 rounded-lg overflow-hidden cursor-pointer group transform hover:scale-105 transition-transform duration-300 shadow-lg hover:shadow-xl"
       // Attempting manual aspect ratio with padding-top
-      className="relative w-full rounded-lg overflow-hidden cursor-pointer group transform hover:scale-105 transition-transform duration-300 shadow-lg hover:shadow-xl"
-      style={{ paddingTop: '100%' }} // For 1:1 aspect ratio. Image component should be absolutely positioned within.
+      className="relative w-full aspect-square rounded-lg overflow-hidden cursor-pointer group transform hover:scale-105 transition-transform duration-300 shadow-lg hover:shadow-xl"
       onClick={onClick}
     >
       <div className="absolute inset-0"> {/* Wrapper for next/image to fill */} 


### PR DESCRIPTION
## Summary
- update gallery item layout to use Tailwind `aspect-square`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f28972908326b02ac5c6a9a23562