### PR TITLE
Remove extra dependency from FadeIn hook

### DIFF
--- a/src/animations/FadeIn.tsx
+++ b/src/animations/FadeIn.tsx
@@ -30,7 +30,7 @@ const FadeIn: React.FC<FadeInProps> = ({
     } else if (!triggerOnce) {
       controls.start('hidden');
     }
-  }, [controls, inView, triggerOnce, className]);
+  }, [controls, inView, triggerOnce]);
 
   const variants = {
     hidden: { opacity: 0 },


### PR DESCRIPTION
## Summary
- remove `className` from FadeIn effect dependency array

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f26dd1648326a424becd31c95dbc